### PR TITLE
Reorder generateContract test mocking

### DIFF
--- a/src/tests/generateContract.test.ts
+++ b/src/tests/generateContract.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest';
-import { generateContract } from '../hooks/useSupabase';
 
 vi.mock('../hooks/useSupabase', async () => {
   const actual = await vi.importActual('../hooks/useSupabase');
@@ -8,6 +7,8 @@ vi.mock('../hooks/useSupabase', async () => {
     generateContract: vi.fn(() => Promise.resolve({ reference: 'REF123', url: 'test.pdf' })),
   };
 });
+
+import { generateContract } from '../hooks/useSupabase';
 
 describe('generateContract', () => {
   it('calls RPC and returns data', async () => {


### PR DESCRIPTION
## Summary
- move mocking for `useSupabase` to the top of `generateContract.test.ts`
- import `generateContract` after the mock

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_685ed2db6da88326972e5c44d818c172